### PR TITLE
fix: handle svg images without natural width and/or height on firefox

### DIFF
--- a/src/utils/image/get-image-size.ts
+++ b/src/utils/image/get-image-size.ts
@@ -5,6 +5,20 @@ export async function getImageSize(blob: Blob): Promise<{
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = function () {
+      if (navigator.userAgent.toLowerCase().includes("firefox") && blob.type === "image/svg+xml") {
+        // mimicking chrome user agent behavior
+        if (!img.naturalWidth && !img.naturalHeight) {
+          img.style.maxWidth = "150px";
+        } else if (!img.naturalWidth) {
+          img.style.width = `${img.naturalHeight}px}`
+        } else if (!img.naturalHeight) {
+          img.style.height = `${img.naturalWidth}px}`
+        }
+
+        // This is needed for all the above cases
+        document.body.append(img);
+      }
+
       resolve({
         height: img.height,
         width: img.width,


### PR DESCRIPTION
I've **attempted** to correct issue #3 and to mimick the handling of SVGs  with a missing height or width attributes as it happens on Chrome, with mixed results.

### Problem - Missing height AND width
If an SVG is provided on Firefox with **no height and no width** assigned, it's size will be `height: 0` `width: 0`, resulting in blank images being generated.
### Solution    
The SVG image will be appended to the DOM with a max-width of `150px` in order to measure its size and allowing the images to be generated correctly afterwards.

I based this arbitrary max-width value on
 - A comment by `Emilio Cobos Álvarez` on https://bugzilla.mozilla.org/show_bug.cgi?id=1607081
 - The behavior of your service on Chrome, when uploading an SVG icon without height and width attributes. e.g. Adding the demo icon results in an 150x150 SVG, same holds true for other SVGs I've used without height/width attributes.
 
### Drawbacks

- I was unable to find more details to support this img element rule `max-width:150px`  on the user agent stylesheet of Chrome.
- There are some discrepancies here and there for bigger SVGs, for example this [grid](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/06049c45-e8e2-48b2-b1d6-f7290c8cdf8b) SVG has a size of 143x150 on chrome while on Firefox my current solution translates it to 150x157


--- 

### Problem - Missing height OR width
If an SVG is provided with **ONLY height OR width**, it's size will be `0 x Height` or `Width x 0`, resulting again in blank images being generated.
### Solution
The SVG image will be appended to the DOM with, in the case of missing height, the height attribute will be equal to the images natural width and vice versa for missing width. - (Natural implies the value assigned on the SVG element)

I based this on the behavior of your service when uploading an SVG icon without height OR width attributes on Chrome.

---
Here are the SVGs I used during the process so far
[angular 0x128](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/4408551c-8e8e-421f-9efe-471a92adf0fc)
[angular 128x0](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/e12046b0-1910-4a80-b7de-2054b31e0d19)
[angular 128x128](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/179f198c-67c6-445c-96a1-1b4a90055d00)
[angular](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/197a9f13-bd20-4298-b66e-e9ff208ba4ba)
[favicon 48x48](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/c6fd01ba-b636-48f1-a4d8-0e0fa9745237)
[favicon 100x100 %](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/c8a0bf03-a2cc-4a53-ba5b-c13626096b55)
[favicon](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/8b2b25e6-b5f1-4a7d-931a-55812b81e2d7)
[grid](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/065111f7-dbdf-4db4-a148-274f38120e28)
[test-svgrepo](https://github.com/InBrowserApp/favicon.inbrowser.app/assets/64101252/851a8b91-cd30-4a7e-9add-af8ab0a3a697)

---

I do not expect this pull request to be merged at this point and of course, if no contributions are to be accepted or Firefox browser is something you do not wish to support, I understand. In that case feel free to close this request.

I am open to any criticism or insight and thanks again for this tool